### PR TITLE
Fetch AWS config from ec2metadata if on an ec2 instance

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,16 +4,16 @@
 PLATFORMS=(
   'darwin:amd64'     # MacOS
   # 'dragonfly:amd64'  # Dragonfly https://www.dragonflybsd.org/
-  'freebsd:amd64'
+#  'freebsd:amd64'
   # 'linux:386'
   'linux:amd64'
   # 'linux:arm'
   # 'linux:arm64'
-  'netbsd:amd64'
-  'openbsd:amd64'
-  'solaris:amd64'
+#  'netbsd:amd64'
+#  'openbsd:amd64'
+#  'solaris:amd64'
   # 'windows:386'
-  'windows:amd64'
+#  'windows:amd64'
 )
 
 echo "Creating summon-aws-secrets binaries in output/"

--- a/build.sh
+++ b/build.sh
@@ -4,16 +4,16 @@
 PLATFORMS=(
   'darwin:amd64'     # MacOS
   # 'dragonfly:amd64'  # Dragonfly https://www.dragonflybsd.org/
-#  'freebsd:amd64'
+  'freebsd:amd64'
   # 'linux:386'
   'linux:amd64'
   # 'linux:arm'
   # 'linux:arm64'
-#  'netbsd:amd64'
-#  'openbsd:amd64'
-#  'solaris:amd64'
+  'netbsd:amd64'
+  'openbsd:amd64'
+  'solaris:amd64'
   # 'windows:386'
-#  'windows:amd64'
+  'windows:amd64'
 )
 
 echo "Creating summon-aws-secrets binaries in output/"

--- a/main.go
+++ b/main.go
@@ -3,15 +3,23 @@ package main
 import (
 	"os"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-sdk-go/aws"
 )
 
 func RetrieveSecret(variableName string) {
+
+	// AWS Go SDK does not currently support automatic fetching of region from ec2metadata
+	// Create metaSession to fetch the region and supply it to the regular Session
+
+	metaSession, _ := session.NewSession()
+	metaClient := ec2metadata.New(metaSession)
+	region, _ := metaClient.Region()
+
+	conf := aws.NewConfig().WithRegion(region)
+
 	// All clients require a Session. The Session provides the client with
 	// shared configuration such as region, endpoint, and credentials. A
 	// Session should be shared where possible to take advantage of
@@ -20,24 +28,18 @@ func RetrieveSecret(variableName string) {
 
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
+		Config: *conf,
 	})
 	if err != nil {
 		printAndExit(err)
 	}
 
-	creds := credentials.NewChainCredentials(
-	[]credentials.Provider{
-		&ec2rolecreds.EC2RoleProvider{
-			Client: ec2metadata.New(sess),
-		},
-		&credentials.EnvProvider{},
-	})
-
 	// Create a new instance of the service's client with a Session.
+	// Optional aws.Config values can also be provided as variadic arguments
+	// to the New function. This option allows you to provide service
+	// specific configuration.
 
-	svc := secretsmanager.New(session.Must(session.NewSession(&aws.Config{
-		Credentials: creds,
-	})))
+	svc := secretsmanager.New(sess)
 
 	// Get secret value
 	req, resp := svc.GetSecretValueRequest(&secretsmanager.GetSecretValueInput{
@@ -67,7 +69,7 @@ func main() {
 
 	singleArgument := os.Args[1]
 	switch singleArgument {
-	case "-v", "--version":
+	case "-v","--version":
 		os.Stdout.Write([]byte(VERSION))
 	default:
 		RetrieveSecret(singleArgument)


### PR DESCRIPTION
Not the prettiest solution, but there doesn't appear to be native support for fetching the region from the ec2 instance it's running on.

Relevant feature request in aws-go-sdk: aws/aws-sdk-go#1103